### PR TITLE
don't check expiry for loader

### DIFF
--- a/thumbor_aws/loader.py
+++ b/thumbor_aws/loader.py
@@ -59,7 +59,6 @@ Config.define(
 
 async def load(context, path):
     """Loader to get source files from S3"""
-
     client = S3Client(context)
     client.configuration = {
         "region_name": context.config.AWS_LOADER_REGION_NAME,
@@ -82,7 +81,9 @@ async def load(context, path):
     norm_path = normalize_url(client.configuration["root_path"], path)
     result = LoaderResult()
 
-    status_code, body, last_modified = await client.get_data(norm_path)
+    status_code, body, last_modified = await client.get_data(
+        norm_path, expiration=None
+    )
 
     if status_code != 200:
         result.error = LoaderResult.ERROR_NOT_FOUND

--- a/thumbor_aws/s3_client.py
+++ b/thumbor_aws/s3_client.py
@@ -17,6 +17,8 @@ from thumbor.config import Config
 from thumbor.context import Context
 from thumbor.utils import logger
 
+_default = object()
+
 
 class S3Client:
     __session: AioSession = None
@@ -142,7 +144,7 @@ class S3Client:
             return f"{location.rstrip('/')}/{path.lstrip('/')}"
 
     async def get_data(
-        self, path: str, expiration: int = None
+        self, path: str, expiration: int = _default
     ) -> (int, bytes, Optional[datetime.datetime]):
         """Gets an object's data from S3"""
 
@@ -213,15 +215,17 @@ class S3Client:
             return await stream.read()
 
     def _is_expired(
-        self, last_modified: datetime.datetime, expiration: int = None
+        self,
+        last_modified: datetime.datetime,
+        expiration: int = _default,
     ) -> bool:
         """Identifies whether an AWS S3 object is expired"""
 
         if expiration is None:
-            expiration = self.config.STORAGE_EXPIRATION_SECONDS
-
-        if expiration is None:
             return False
+
+        if expiration is _default:
+            expiration = self.config.STORAGE_EXPIRATION_SECONDS
 
         timediff = datetime.datetime.now(datetime.timezone.utc) - last_modified
         return timediff.total_seconds() > expiration


### PR DESCRIPTION
I added a sentinel value to make as little change as possible. It can probably be done in a cleaner way than this, I am just not sure which direction you might want to go.

I don't believe there is anyone that actually wants to invalidate objects in the loader based on age so ignoring it seems reasonable.

closes #8