### PR TITLE
Remove Code climate from the build GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,3 @@ jobs:
         run: |
           pip install --upgrade coveralls
           coveralls --service=github
-      - name: Code Climate After Build
-        if: matrix.python-version == '3.10'
-        run: |-
-          ./test-reporter-latest-linux-amd64 after-build -t cobertura --exit-code 0 -r "${{ secrets.CODE_CLIMATE_TOKEN }}"


### PR DESCRIPTION
Secrets are not available for outside collaborators, this
will make the build fail for every external collaborator