### PR TITLE
Remove default part from file path when not WebP

### DIFF
--- a/tests/test_result_storage.py
+++ b/tests/test_result_storage.py
@@ -44,7 +44,7 @@ class ResultStorageTestCase(BaseS3TestCase):
         Result Storage works and the image is there
         """
         await self.ensure_bucket()
-        filepath = f"/test/can_put_file_{uuid4()}"
+        filepath = f"test/can_put_file_{uuid4()}"
         self.context.request = Mock(url=filepath)
         storage = ResultStorage(self.context)
         expected = self.test_images["default"]
@@ -53,10 +53,10 @@ class ResultStorageTestCase(BaseS3TestCase):
 
         expect(path).to_equal(
             f"https://{self.bucket_name}.s3.localhost.localstack.cloud:4566"
-            f"{self._prefix}/default{filepath}",
+            f"{self._prefix}/{filepath}",
         )
         status, data, _ = await storage.get_data(
-            f"{self._prefix}/default{filepath}"
+            f"{self._prefix}/{filepath}"
         )
         expect(status).to_equal(200)
         expect(data).to_equal(expected)

--- a/thumbor_aws/result_storage.py
+++ b/thumbor_aws/result_storage.py
@@ -161,11 +161,11 @@ class Storage(BaseStorage, S3Client):
 
     def normalize_path(self, path: str) -> str:
         """Returns the path used for result storage"""
-        prefix = "auto_webp" if self.is_auto_webp else "default"
+        prefix = "auto_webp/" if self.is_auto_webp else ""
         fs_path = unquote(path).lstrip("/")
         return (
             f"{self.root_path.rstrip('/')}/"
-            f"{prefix.lstrip('/')}/"
+            f"{prefix.lstrip('/')}"
             f"{fs_path.lstrip('/')}"
         )
 


### PR DESCRIPTION
This PR fixes #16 to allow a compatible path between thumbor-aws and tc_aws.