### PR TITLE
Allow empty Bucket on loader

### DIFF
--- a/tests/test_result_storage.py
+++ b/tests/test_result_storage.py
@@ -56,7 +56,7 @@ class ResultStorageTestCase(BaseS3TestCase):
             f"{self._prefix}/{filepath}",
         )
         status, data, _ = await storage.get_data(
-            f"{self._prefix}/{filepath}"
+            self.bucket_name, f"{self._prefix}/{filepath}"
         )
         expect(status).to_equal(200)
         expect(data).to_equal(expected)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -44,7 +44,7 @@ class StorageTestCase(BaseS3TestCase):
             f"{self._prefix}{filepath}",
         )
         status, data, _ = await storage.get_data(
-            storage.normalize_path(filepath)
+            self.bucket_name, storage.normalize_path(filepath)
         )
         expect(status).to_equal(200)
         expect(data).to_equal(expected)
@@ -66,7 +66,7 @@ class StorageTestCase(BaseS3TestCase):
             f"{self._prefix}{filepath}.txt",
         )
         status, data, _ = await storage.get_data(
-            storage.normalize_path(filepath + ".txt")
+            self.bucket_name, storage.normalize_path(filepath + ".txt")
         )
         expect(status).to_equal(200)
         expect(data).to_equal("ACME-SEC")
@@ -90,7 +90,8 @@ class StorageTestCase(BaseS3TestCase):
             f"{self._prefix}{filepath}.detectors.txt",
         )
         status, data, _ = await storage.get_data(
-            storage.normalize_path(filepath + ".detectors.txt")
+            self.bucket_name,
+            storage.normalize_path(filepath + ".detectors.txt"),
         )
         expect(status).to_equal(200)
         expect(data).to_equal(b'{"some": "data"}')
@@ -121,7 +122,7 @@ class StorageTestCase(BaseS3TestCase):
         await storage.put(filepath, expected)
 
         status, data, _ = await storage.get_data(
-            storage.normalize_path(filepath), expiration=0
+            self.bucket_name, storage.normalize_path(filepath), expiration=0
         )
 
         expect(status).to_equal(410)

--- a/thumbor_aws/result_storage.py
+++ b/thumbor_aws/result_storage.py
@@ -182,7 +182,9 @@ class Storage(BaseStorage, S3Client):
             )
             return None
 
-        status, body, last_modified = await self.get_data(file_abspath)
+        status, body, last_modified = await self.get_data(
+            self.bucket_name, file_abspath
+        )
 
         if status != 200 or self._is_expired(last_modified):
             logger.debug(

--- a/thumbor_aws/storage.py
+++ b/thumbor_aws/storage.py
@@ -140,7 +140,9 @@ class Storage(storages.BaseStorage, S3Client):
 
     async def get(self, path: str) -> bytes:
         normalized_path = self.normalize_path(path)
-        status, body, _ = await self.get_data(normalized_path)
+        status, body, _ = await self.get_data(
+            self.bucket_name, normalized_path
+        )
         if status != 200:
             return None
 
@@ -149,7 +151,7 @@ class Storage(storages.BaseStorage, S3Client):
     async def get_crypto(self, path: str) -> str:
         normalized_path = self.normalize_path(path)
         crypto_path = f"{normalized_path}.txt"
-        status, body, _ = await self.get_data(crypto_path)
+        status, body, _ = await self.get_data(self.bucket_name, crypto_path)
         if status != 200:
             return None
 
@@ -158,7 +160,7 @@ class Storage(storages.BaseStorage, S3Client):
     async def get_detector_data(self, path: str) -> Any:
         normalized_path = self.normalize_path(path)
         detector_path = f"{normalized_path}.detectors.txt"
-        status, body, _ = await self.get_data(detector_path)
+        status, body, _ = await self.get_data(self.bucket_name, detector_path)
         if status != 200:
             return None
 


### PR DESCRIPTION
This PR resolves issue #18.
It also corrects a flaky test that appears when the tests are executed too fast.

```bash
==============================================================================
ERROR: tests/test_storage.py::StorageTestCase::test_can_handle_expired_data
------------------------------------------------------------------------------
2022-05-01 11:24:51.146905+00:00
2022-05-01 11:24:51+00:00

Traceback (most recent call last):
  File "/Users/guilhermesouza/projects/thumbor-aws/tests/test_storage.py", line 124, in test_can_handle_expired_data
    status, data, _ = await storage.get_data(
  File "/Users/guilhermesouza/projects/thumbor-aws/thumbor_aws/s3_client.py", line 164, in get_data
    if self._is_expired(last_modified, expiration):
  File "/Users/guilhermesouza/projects/thumbor-aws/thumbor_aws/s3_client.py", line 242, in _is_expired
    return timediff.total_seconds() >= expiration
AttributeError: 'float' object has no attribute 'total_seconds'

```
