### PR TITLE
Change log line that may be hit on every requerts to instead be warning

### DIFF
--- a/thumbor_aws/s3_client.py
+++ b/thumbor_aws/s3_client.py
@@ -9,6 +9,7 @@
 # Copyright (c) 2021 Bernardo Heynemann heynemann@gmail.com
 
 import datetime
+import warnings
 from typing import Any, Dict, Mapping, Optional, Tuple
 
 from aiobotocore.client import AioBaseClient
@@ -136,7 +137,7 @@ class S3Client:
                     f"Unable to process response from AWS to {path}: "
                     "Location Headers was not found in response"
                 )
-                logger.warning(msg)
+                warnings.warn(msg, UserWarning)
                 location = default_location.format(
                     bucket_name=self.bucket_name
                 )


### PR DESCRIPTION
Users of systems like Sentry may otherwise get hammered with warning-level log messages.

The `location` may not even be present for users of S3 although it might be for other S3-compatible implementations.

Fixes #65.