### PR TITLE
Move the `AWS_NORMALIZER` config to top-level configuration list

### DIFF
--- a/thumbor_aws/config.py
+++ b/thumbor_aws/config.py
@@ -8,6 +8,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2021 Bernardo Heynemann heynemann@gmail.com
 
+from urllib.parse import unquote
 
 from thumbor.config import Config, config
 
@@ -122,6 +123,13 @@ Config.define(
     False,
     "Store result with metadata (for instance content-type)",
     "tc_aws Compatibility",
+)
+
+Config.define(
+    "AWS_NORMALIZER",
+    lambda path: unquote(path).lstrip("/"),
+    "How to normalize storage paths before adding the prefix",
+    "AWS Storage",
 )
 
 

--- a/thumbor_aws/storage.py
+++ b/thumbor_aws/storage.py
@@ -10,7 +10,6 @@
 
 from json import dumps, loads
 from typing import Any
-from urllib.parse import unquote
 
 from thumbor import storages
 from thumbor.engines import BaseEngine
@@ -67,13 +66,6 @@ Config.define(
     "AWS_STORAGE_S3_ACL",
     "public-read",
     "Storage ACL for files written in bucket",
-    "AWS Storage",
-)
-
-Config.define(
-    "AWS_NORMALIZER",
-    lambda path: unquote(path).lstrip("/"),
-    "How to normalize storage paths before adding the prefix",
     "AWS Storage",
 )
 


### PR DESCRIPTION
The `AWS_NORMALIZER` configuration is used for both the storage and result storage modules, but there's no requirement to use the storage module if you only need the result storage module. In that case, you might have the storage module configured with:

```
STORAGE = "thumbor.storages.no_storage"
```

In that case, the `thumbor_aws.storage` file is never loaded, which means the `AWS_NORMALIZER` configuration never gets defined, which in turn means any requests for the result storage module which tries to call `normalize_path` will fail with an error like this:

```
2025-08-26 08:08:38 thumbor:ERROR [BaseHander.execute_image_operations] AWS_NORMALIZER
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/thumbor/handlers/__init__.py", line 145, in execute_image_operations
    result = await self.context.modules.result_storage.get()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/thumbor_aws/result_storage.py", line 168, in get
    file_abspath = normalize_path(self.context, self.prefix, path)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/thumbor_aws/utils.py", line 9, in normalize_path
    new_path = context.config.AWS_NORMALIZER(path)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/derpconf/config.py", line 225, in __getattr__
    raise AttributeError(name)
AttributeError: AWS_NORMALIZER
```

This fixes that by moving the configuration setting to the top-level config file to make sure it's always defined, regardless of if `thumbor_aws.storage` is used or not.